### PR TITLE
Lab01-analyze-images Python script with wrong indent

### DIFF
--- a/Labfiles/01-analyze-images/Python/image-analysis/image-analysis.py
+++ b/Labfiles/01-analyze-images/Python/image-analysis/image-analysis.py
@@ -32,7 +32,7 @@ def main():
         # Analyze image
         AnalyzeImage(image_file, image_data, cv_client)
         
-        except Exception as ex:
+    except Exception as ex:
         print(ex)
 
 


### PR DESCRIPTION
The Python script file "image-analysis.py" is having wrong indent on line 35 which will lead to "SyntaxError". Please remove one indent to have the correct alignment. This was happening on my training delivery on the week of Jan 27th 2025. Thanks!

![Screenshot 2025-02-03 111353](https://github.com/user-attachments/assets/b8772ea1-92fa-4fe6-9158-7c0b721eb124)
