### PR TITLE
Backfill missing lab metadata (13 files)

### DIFF
--- a/Instructions/Exercises/01-dall-e.md
+++ b/Instructions/Exercises/01-dall-e.md
@@ -1,7 +1,12 @@
 ---
 lab:
-    title: 'Generate images with AI'
-    description: 'Use an OpenAI image generation model in Microsoft Foundry to generate images.'
+  title: Generate images with AI
+  description: Use an OpenAI image generation model in Microsoft Foundry to generate images.
+  duration: 30 minutes
+  level: 200
+  islab: true
+  primarytopics:
+    - Microsoft Foundry
 ---
 
 # Generate images with AI

--- a/Instructions/Exercises/01-generate-image.md
+++ b/Instructions/Exercises/01-generate-image.md
@@ -1,7 +1,12 @@
 ---
 lab:
-    title: 'Generate images with AI'
-    description: 'Use an image generation model in Microsoft Foundry to generate images.'
+  title: Generate images with AI
+  description: Use an image generation model in Microsoft Foundry to generate images.
+  duration: 30 minutes
+  level: 200
+  islab: true
+  primarytopics:
+    - Microsoft Foundry
 ---
 
 # Generate images with AI

--- a/Instructions/Exercises/02-generate-video.md
+++ b/Instructions/Exercises/02-generate-video.md
@@ -1,9 +1,12 @@
 ---
 lab:
-    title: 'Generate video with Sora in Microsoft Foundry'
-    description: 'Learn how to generate AI-powered video content using the Sora model in Microsoft Foundry.'
-    level: 300
-    duration: 45
+  title: Generate video with Sora in Microsoft Foundry
+  description: Learn how to generate AI-powered video content using the Sora model in Microsoft Foundry.
+  level: 300
+  duration: 45
+  islab: true
+  primarytopics:
+    - Microsoft Foundry
 ---
 
 # Generate video with Sora in Microsoft Foundry

--- a/Instructions/Exercises/03-content-understanding.md
+++ b/Instructions/Exercises/03-content-understanding.md
@@ -1,9 +1,13 @@
 ---
 lab:
-    title: 'Analyze images with Azure Content Understanding'
-    description: 'Learn how to use Azure Content Understanding to analyze images and generate descriptive metadata.'
-    level: 300
-    duration: 30
+  title: Analyze images with Azure Content Understanding
+  description: Learn how to use Azure Content Understanding to analyze images and generate descriptive metadata.
+  level: 300
+  duration: 30
+  islab: true
+  primarytopics:
+    - Azure
+    - Azure Content Understanding
 ---
 
 # Analyze images with Azure Content Understanding

--- a/Instructions/Exercises/04-gen-ai-vision.md
+++ b/Instructions/Exercises/04-gen-ai-vision.md
@@ -1,7 +1,12 @@
 ---
 lab:
-    title: 'Develop a vision-enabled chat app'
-    description: 'Use Azure AI Foundry to build a generative AI app that supports image input.'
+  title: Develop a vision-enabled chat app
+  description: Use Azure AI Foundry to build a generative AI app that supports image input.
+  duration: 30 minutes
+  level: 300
+  islab: true
+  primarytopics:
+    - Azure
 ---
 
 # Develop a vision-enabled chat app

--- a/Instructions/Labs/01-analyze-images.md
+++ b/Instructions/Labs/01-analyze-images.md
@@ -1,7 +1,12 @@
 ---
 lab:
-    title: 'Analyze images'
-    description: 'Use Azure AI Vision Image Analysis to analyze images, suggest captions and tags, and detect objects and people.'
+  title: Analyze images
+  description: Use Azure AI Vision Image Analysis to analyze images, suggest captions and tags, and detect objects and people.
+  duration: 30 minutes
+  level: 300
+  islab: true
+  primarytopics:
+    - Azure
 ---
 
 # Analyze images

--- a/Instructions/Labs/02-ocr.md
+++ b/Instructions/Labs/02-ocr.md
@@ -1,7 +1,12 @@
 ---
 lab:
-    title: 'Read text in images'
-    description: 'Use optical character recognition (OCR) in the Azure AI Vision Image Analysis service to locate and extract text in images.'
+  title: Read text in images
+  description: Use optical character recognition (OCR) in the Azure AI Vision Image Analysis service to locate and extract text in images.
+  duration: 30 minutes
+  level: 300
+  islab: true
+  primarytopics:
+    - Azure
 ---
 
 # Read text in images

--- a/Instructions/Labs/03-face-service.md
+++ b/Instructions/Labs/03-face-service.md
@@ -1,7 +1,12 @@
 ---
 lab:
-    title: 'Detect and analyze faces'
-    description: 'Use the Azure AI Vision Face service to implement face detection and analysis solutions.'
+  title: Detect and analyze faces
+  description: Use the Azure AI Vision Face service to implement face detection and analysis solutions.
+  duration: 30 minutes
+  level: 300
+  islab: true
+  primarytopics:
+    - Azure
 ---
 
 # Detect and analyze faces

--- a/Instructions/Labs/04-image-classification.md
+++ b/Instructions/Labs/04-image-classification.md
@@ -1,7 +1,12 @@
 ---
 lab:
-    title: 'Classify images'
-    description: "Use the Azure AI Custom Vision service to train an image classification model."
+  title: Classify images
+  description: Use the Azure AI Custom Vision service to train an image classification model.
+  duration: 45 minutes
+  level: 300
+  islab: true
+  primarytopics:
+    - Azure
 ---
 
 # Classify images

--- a/Instructions/Labs/05-custom-vision-object-detection.md
+++ b/Instructions/Labs/05-custom-vision-object-detection.md
@@ -1,7 +1,12 @@
 ---
 lab:
-    title: 'Detect objects in images'
-    description: 'Use the Azure AI Custom Vision service to train an object detection model.'
+  title: Detect objects in images
+  description: Use the Azure AI Custom Vision service to train an object detection model.
+  duration: 45 minutes
+  level: 300
+  islab: true
+  primarytopics:
+    - Azure
 ---
 
 # Detect objects in images

--- a/Instructions/Labs/06-video-indexer.md
+++ b/Instructions/Labs/06-video-indexer.md
@@ -1,7 +1,12 @@
 ---
 lab:
-    title: 'Analyze video'
-    description: 'Use Azure AI Video Indexer to analyze a video.'
+  title: Analyze video
+  description: Use Azure AI Video Indexer to analyze a video.
+  duration: 110 minutes
+  level: 200
+  islab: true
+  primarytopics:
+    - Azure
 ---
 
 # Analyze video

--- a/Instructions/Labs/08-gen-ai-vision.md
+++ b/Instructions/Labs/08-gen-ai-vision.md
@@ -1,7 +1,12 @@
 ---
 lab:
-    title: 'Develop a vision-enabled chat app'
-    description: 'Use Azure AI Foundry to build a generative AI app that supports image input.'
+  title: Develop a vision-enabled chat app
+  description: Use Azure AI Foundry to build a generative AI app that supports image input.
+  duration: 30 minutes
+  level: 400
+  islab: true
+  primarytopics:
+    - Azure
 ---
 
 # Develop a vision-enabled chat app

--- a/Instructions/Labs/09-dall-e.md
+++ b/Instructions/Labs/09-dall-e.md
@@ -1,7 +1,12 @@
 ---
 lab:
-    title: 'Generate images with AI'
-    description: 'Use an OpenAI a DALL-E model in Azure AI Foundry to generate images.'
+  title: Generate images with AI
+  description: Use an OpenAI a DALL-E model in Azure AI Foundry to generate images.
+  duration: 30 minutes
+  level: 300
+  islab: true
+  primarytopics:
+    - Azure
 ---
 
 # Generate images with AI


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 13

- `Instructions/Exercises/01-dall-e.md` (duration,level,islab,primarytopics)
- `Instructions/Exercises/01-generate-image.md` (duration,level,islab,primarytopics)
- `Instructions/Exercises/02-generate-video.md` (islab,primarytopics)
- `Instructions/Exercises/03-content-understanding.md` (islab,primarytopics)
- `Instructions/Exercises/04-gen-ai-vision.md` (duration,level,islab,primarytopics)
- `Instructions/Labs/01-analyze-images.md` (duration,level,islab,primarytopics)
- `Instructions/Labs/02-ocr.md` (duration,level,islab,primarytopics)
- `Instructions/Labs/03-face-service.md` (duration,level,islab,primarytopics)
- `Instructions/Labs/04-image-classification.md` (duration,level,islab,primarytopics)
- `Instructions/Labs/05-custom-vision-object-detection.md` (duration,level,islab,primarytopics)
- `Instructions/Labs/06-video-indexer.md` (duration,level,islab,primarytopics)
- `Instructions/Labs/08-gen-ai-vision.md` (duration,level,islab,primarytopics)
- `Instructions/Labs/09-dall-e.md` (duration,level,islab,primarytopics)
