### PR TITLE
Change video requested size from 720x1280 to 1280x720 to match reference image

### DIFF
--- a/Instructions/Exercises/03-generate-video.md
+++ b/Instructions/Exercises/03-generate-video.md
@@ -195,7 +195,7 @@ The initial application files you'll need to develop the translation application
     video = generate_video_from_image(
         image_path="reference.png",
         prompt="The scene comes to life with gentle movement and ambient lighting",
-        size="720x1280",
+        size="1280x720",
         seconds='4'
     )
     if video.status == "completed":


### PR DESCRIPTION
Fixing error when the video request doesn't match the reference.png sizing

Reference.png
<img width="333" height="216" alt="image" src="https://github.com/user-attachments/assets/da19d4b8-57c4-4cd6-9172-66b3bd5c01aa" />

A mismatch will result in the following error message...

```
Step 3: Generating a video from a reference image...
Starting video generation from image: reference.png
Error code: 400 - {'error': {'message': 'Inpaint image must match the requested width and height', 'type': 'invalid_request_error', 'param': None, 'code': None}}
```



