### PR TITLE
LAB04 : Update storage type label to primary service in content understanding lab

### DIFF
--- a/Instructions/Exercises/04-content-understanding.md
+++ b/Instructions/Exercises/04-content-understanding.md
@@ -58,7 +58,7 @@ You'll need an Azure storage account for the content assets you're going to anal
     - **Resource group**: *The resource group containing your Foundry resource*
     - **Storage account name**: *A unique name for your storage account*
     - **Region**: *The same region as your Foundry resource*
-    - **Preferred storage type**: Azure Blob Storage or Azure Data Lake Storage Gen 2
+    - **Primary service**: Azure Blob Storage or Azure Data Lake Storage Gen 2
     - **Performance**: Standard
     - **Redundancy**: Locally-redundant storage (LRS)
 1. Wait for your storage account to be created.


### PR DESCRIPTION
This pull request makes a minor wording update to the storage account setup instructions, clarifying the terminology used.

* Updated the instruction from "Preferred storage type" to "Primary service" when specifying Azure Blob Storage or Azure Data Lake Storage Gen 2.